### PR TITLE
rename app ID from org.mozilla.firefox to .Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Now we're ready to run ```build.sh```, which will build Firefox from master bran
 
 After the build is finished you can start sandboxed Firefox:
 ```
-$ flatpak run org.mozilla.firefox
+$ flatpak run org.mozilla.Firefox
 ```

--- a/build.sh
+++ b/build.sh
@@ -3,12 +3,12 @@
 set -ux
 
 rm -rf app
-flatpak-builder --ccache --require-changes --repo=repo --subject="Nightly build of Firefox, `date`" app org.mozilla.firefox.json
+flatpak-builder --ccache --require-changes --repo=repo --subject="Nightly build of Firefox, `date`" app org.mozilla.Firefox.json
 
 flatpak build-update-repo --prune --prune-depth=20 repo
 
 # The following commands should be performed once
 flatpak --user remote-add --no-gpg-verify nightly-firefox ./repo || true
-flatpak --user -v install nightly-firefox org.mozilla.firefox || true
+flatpak --user -v install nightly-firefox org.mozilla.Firefox || true
 
-flatpak update --user org.mozilla.firefox
+flatpak update --user org.mozilla.Firefox

--- a/org.mozilla.Firefox.json
+++ b/org.mozilla.Firefox.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "org.mozilla.firefox",
+    "app-id": "org.mozilla.Firefox",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.22",
     "sdk": "org.gnome.Sdk",


### PR DESCRIPTION
The D-Bus / GNOME conventions for naming app IDs is to lowercase the domain part,
and then use camel-case for the app name and app-owned namespaces.